### PR TITLE
Update mesh.py

### DIFF
--- a/utils/exporters/blender/addons/io_three/exporter/api/mesh.py
+++ b/utils/exporters/blender/addons/io_three/exporter/api/mesh.py
@@ -616,7 +616,7 @@ def normals(mesh):
     normal_vectors = []
 
     for vector in _normals(mesh):
-        vector = (vector[0], vector[2], -vector[1])
+        vector = (vector[0], vector[1], vector[2])
         normal_vectors.extend(vector)
 
     return normal_vectors


### PR DESCRIPTION
changed vector order in normals calculation function to fix issues with illumination in JSON exports.